### PR TITLE
fix: SD not always recognized, pull all CS signals high at start

### DIFF
--- a/boards/lilygo-t-embed-cc1101/interface.cpp
+++ b/boards/lilygo-t-embed-cc1101/interface.cpp
@@ -39,6 +39,12 @@ void _setup_gpio() {
       pinMode(CC1101_SW1_PIN, OUTPUT);
       pinMode(CC1101_SW0_PIN, OUTPUT);
 
+      // before powering on, all CS signals should be pulled high and in an unselected state;
+      pinMode(TFT_CS, OUTPUT);
+      digitalWrite(TFT_CS, HIGH);
+      pinMode(SDCARD_CS, OUTPUT);
+      digitalWrite(SDCARD_CS, HIGH);
+
       // Chip Select CC1101 to HIGH State
       pinMode(CC1101_SS_PIN, OUTPUT);
       digitalWrite(CC1101_SS_PIN,HIGH);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,6 +219,13 @@ void _post_setup_gpio() { }
 void setup() {
   Serial.begin(115200);
 
+  pinMode(TFT_CS, OUTPUT);
+  digitalWrite(TFT_CS, HIGH);
+  pinMode(SDCARD_CS, OUTPUT);
+  digitalWrite(SDCARD_CS, HIGH);
+  pinMode(CC1101_SS_PIN, OUTPUT);
+  digitalWrite(CC1101_SS_PIN, HIGH);
+
   // Setup GPIOs and stuff
   #if defined(HEADLESS)
     #if SEL_BTN >= 0 // handle enter in launcher

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,13 +219,6 @@ void _post_setup_gpio() { }
 void setup() {
   Serial.begin(115200);
 
-  pinMode(TFT_CS, OUTPUT);
-  digitalWrite(TFT_CS, HIGH);
-  pinMode(SDCARD_CS, OUTPUT);
-  digitalWrite(SDCARD_CS, HIGH);
-  pinMode(CC1101_SS_PIN, OUTPUT);
-  digitalWrite(CC1101_SS_PIN, HIGH);
-
   // Setup GPIOs and stuff
   #if defined(HEADLESS)
     #if SEL_BTN >= 0 // handle enter in launcher


### PR DESCRIPTION
Possible Fix for https://github.com/bmorcelli/M5Stick-Launcher/issues/113
Tested Device: T-Embed CC1101
I encountered the same issue where the SD card was not recognized after a restart. However, reinserting the SD card and performing a reset using the internal button allowed it to be detected again.

With this fix, the SD card is now consistently recognized on restart. I tested it with two SD cards that initially exhibited the issue:

1GB FAT32
64GB (partitioned to 32GB FAT32)
Approach:
To rule out faulty hardware, I first tested the tf_card_test example from the [T-Embed repo](https://github.com/Xinyuan-LilyGO/T-Embed-CC1101/tree/master/examples/tf_card_test), which worked correctly. Based on that, I adapted its setup code for the M5Stick Launcher, and this resolved the issue on my device.

While this fix has worked reliably in my testing, it has only been tested on the T-Embed CC1101, so broader validation would be helpful. Feedback and improvements are welcome!