### PR TITLE
Renaming additional URLs used in the web UI

### DIFF
--- a/src/webInterface.h
+++ b/src/webInterface.h
@@ -307,7 +307,7 @@ color: #ad007c65;
 <h1 align="center">-= Launcher =-</h1>
 <p>Firmware version: %FIRMWARE%</p>
 <p>Free Storage: <span id="freeSD">%FREESD%</span> | Used: <span id="usedSD">%USEDSD%</span> | Total: <span id="totalSD">%TOTALSD%</span></p>
-<p><a href="https://bmorcelli.github.io/M5Stick-Launcher/m5lurner.html" target="_blank" rel="noopener noreferrer">Online Firmware list from M5Burner (Need Internet)</a></p>
+<p><a href="https://bmorcelli.github.io/Launcher/m5lurner.html" target="_blank" rel="noopener noreferrer">Online Firmware list from M5Burner (Need Internet)</a></p>
 <p>
 <form id="save" enctype="multipart/form-data" method="post"><input type="hidden" id="actualFolder" name="actualFolder" value="/"></form>
 <button onclick="rebootButton()">Reboot</button>
@@ -849,7 +849,7 @@ th:last-child, td:last-child { width: 100px; text-align: center; }
 <h1 align="center">-= Launcher =-</h1>
 <p>Firmware version: %FIRMWARE%</p>
 <p>Free Storage: <span id="freeSD">%FREESD%</span> | Used: <span id="usedSD">%USEDSD%</span> | Total: <span id="totalSD">%TOTALSD%</span></p>
-<p><a href="https://bmorcelli.github.io/M5Stick-Launcher/m5lurner.html" target="_blank" rel="noopener noreferrer">Online Firmware list from M5Burner (Need Internet)</a></p>
+<p><a href="https://bmorcelli.github.io/Launcher/m5lurner.html" target="_blank" rel="noopener noreferrer">Online Firmware list from M5Burner (Need Internet)</a></p>
 <p>
 <form id="save" enctype="multipart/form-data" method="post"><input type="hidden" id="actualFolder" name="actualFolder" value="/"></form>
 <button onclick="rebootButton()">Reboot</button>

--- a/webUi/index.html
+++ b/webUi/index.html
@@ -12,7 +12,7 @@
 <p>Firmware version: <span id="firmwareVersion">...</span></p>
 <p>SD Free Storage: <span id="freeSD">...</span> | Used: <span id="usedSD">...</span> | Total: <span
 id="totalSD">...</span></p>
-<p><a href="https://bmorcelli.github.io/M5Stick-Launcher/m5lurner.html" target="_blank"
+<p><a href="https://bmorcelli.github.io/Launcher/m5lurner.html" target="_blank"
 rel="noopener noreferrer">Online Firmware list from M5Burner (Need Internet)</a></p>
 <div>
 <form id="save" enctype="multipart/form-data" method="post"><input type="hidden" id="actualFolder"


### PR DESCRIPTION
Noticed some URLs in the web UI were out of date, missed in f944e124b4b8db42d7bc27c910d58717b1542026.