### PR TITLE
Enable ESP-IDF build with Arduino component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
+# Include board specific sources before defining the project
+list(APPEND EXTRA_COMPONENT_DIRS boards/m5stack-cardputer)
+
 set(COMPONENTS src)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(Launcher)
-list(APPEND EXTRA_COMPONENT_DIRS boars/m5stack-cardputer)

--- a/boards/m5stack-cardputer/CMakeLists.txt
+++ b/boards/m5stack-cardputer/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "interface.cpp"
+    INCLUDE_DIRS "." "../../include" "../../src"
+    REQUIRES arduino
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 # This file was automatically generated for projects
 # without default 'CMakeLists.txt' file.
 
-FILE(GLOB_RECURSE app_sources ${CMAKE_SOURCE_DIR}/src/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_SOURCE_DIR}/src/*.cpp ${CMAKE_SOURCE_DIR}/src/*.c)
 
-idf_component_register(SRCS ${app_sources})
+idf_component_register(SRCS ${app_sources}
+                      INCLUDE_DIRS "." "../include"
+                      REQUIRES arduino)

--- a/src/idf_component.yml
+++ b/src/idf_component.yml
@@ -1,0 +1,3 @@
+dependencies:
+  espressif/arduino-esp32: "^3.0.0"
+idf_version: ">=5.5.1"


### PR DESCRIPTION
## Summary
- configure project to fetch `arduino-esp32` for IDF 5.5.1
- register board interface as a component
- update CMake files to require Arduino
- fix board CMake syntax

## Testing
- `idf.py build`


------
https://chatgpt.com/codex/tasks/task_e_68badb42a9ac832c8e38dd76189a797b