### PR TITLE
Mac USB mode fix

### DIFF
--- a/src/massStorage.cpp
+++ b/src/massStorage.cpp
@@ -37,9 +37,9 @@ constexpr tusb_desc_device_t kDeviceDescriptor = {
     sizeof(tusb_desc_device_t),
     TUSB_DESC_DEVICE,
     0x0200,
-    TUSB_CLASS_MSC,
-    MSC_SUBCLASS_SCSI,
-    MSC_PROTOCOL_BOT,
+    0x00,              // bDeviceClass    - defined at interface level (fixes macOS MSC enumeration)
+    0x00,              // bDeviceSubClass - defined at interface level
+    0x00,              // bDeviceProtocol - defined at interface level
     CFG_TUD_ENDOINT0_SIZE,
     0x303A,
     0x1001,


### PR DESCRIPTION
Per the USB MSC spec, class/subclass/protocol must be defined at the interface level, not the device level. Setting them at the device level (`TUSB_CLASS_MSC` / `MSC_SUBCLASS_SCSI` / `MSC_PROTOCOL_BOT`) causes macOS to reject enumeration of the mass storage interface entirely. The device shows in System Information as 'Removable' but never appears in Finder or Disk Utility.

Setting `bDeviceClass=0x00`, `bDeviceSubClass=0x00`, `bDeviceProtocol=0x00` tells the host to look at the interface descriptor for class info, which `TUD_MSC_DESCRIPTOR` already sets correctly. This matches the behavior of CircuitPython and other correct USB MSC implementations, and fixes macOS compatibility without affecting Windows or Linux.